### PR TITLE
Update of formula for r53-ddns tag v0.1.3-test2

### DIFF
--- a/Formula/r53-ddns.rb
+++ b/Formula/r53-ddns.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class R53ddns < Formula
-  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v0.1.3-test1.tar.gz"
-  version "v0.1.3-test1"
-  sha256 "d4451c472b9bb84e9f925be7d56bc47900301ca1147ec3b141648c7750bd1057"
+  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v0.1.3-test2.tar.gz"
+  version "v0.1.3-test2"
+  sha256 "91a55f3ba864543425136dc367c2b2c759323920d9ac523bd217b2336a56ed69"
   desc "Amazon Route 53 DDNS - `r53-ddns` - a way to keep a consistant url for a network where the external ip address may change via Amazon Route 53."
   homepage "http://r53-ddns.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v0.1.3-test2
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow