### PR TITLE
Update of formula for r53-ddns tag v0.1.5

### DIFF
--- a/Formula/r53-ddns.rb
+++ b/Formula/r53-ddns.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class R53Ddns < Formula
-  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v0.1.4.tar.gz"
-  version "v0.1.4"
-  sha256 "5af4317e06f38fa90d6201dd8e37830e92a7fa5bd7d4d6362a7c1bc88e1f843a"
+  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v0.1.5.tar.gz"
+  version "v0.1.5"
+  sha256 "825a76ac3063029fae76f80059a83440a3f877199176ee475b7284c70a326064"
   desc "Amazon Route 53 DDNS - `r53-ddns` - a way to keep a consistant url for a network where the external ip address may change via Amazon Route 53."
   homepage "http://r53-ddns.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v0.1.5
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow