### PR TITLE
Update of formula for r53-ddns tag v0.1.6

### DIFF
--- a/Formula/r53-ddns.rb
+++ b/Formula/r53-ddns.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class R53Ddns < Formula
-  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v0.1.5.tar.gz"
-  version "v0.1.5"
-  sha256 "825a76ac3063029fae76f80059a83440a3f877199176ee475b7284c70a326064"
+  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v0.1.6.tar.gz"
+  version "v0.1.6"
+  sha256 "c4d231be5ddfaa2fc56a87c63cc5051a52c813c1378559744a2cf937f0d37c41"
   desc "Amazon Route 53 DDNS - `r53-ddns` - a way to keep a consistant url for a network where the external ip address may change via Amazon Route 53."
   homepage "http://r53-ddns.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v0.1.6
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow