### PR TITLE
Update of formula for r53-ddns tag v0.1.8

### DIFF
--- a/Formula/r53-ddns.rb
+++ b/Formula/r53-ddns.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class R53Ddns < Formula
-  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v0.1.7.tar.gz"
-  version "v0.1.7"
-  sha256 "642acdeba382babd25384f7fb4b83710913abcdc830e384d0cdeef156a4056f2"
+  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v0.1.8.tar.gz"
+  version "v0.1.8"
+  sha256 "c57b95afd8427ff5558a72be5d9760bb74817577dd752cad7a7fab1a5271aa11"
   desc "Amazon Route 53 DDNS - `r53-ddns` - a way to keep a consistant url for a network where the external ip address may change via Amazon Route 53."
   homepage "http://r53-ddns.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v0.1.8
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow