### PR TITLE
Update of formula for r53-ddns tag v0.1.10

### DIFF
--- a/Formula/r53-ddns.rb
+++ b/Formula/r53-ddns.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class R53Ddns < Formula
-  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v0.1.9.tar.gz"
-  version "v0.1.9"
-  sha256 "9c6e4045f6bf9f38617b57b220282cd20ea2d02de762a531507e2d3de107b5c1"
+  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v0.1.10.tar.gz"
+  version "v0.1.10"
+  sha256 "7e94712fbb4c677fe9341a861603091d2c16bc431ea37e56f6fcdd5c442a7b5d"
   desc "Amazon Route 53 DDNS - `r53-ddns` - a way to keep a consistant url for a network where the external ip address may change via Amazon Route 53."
   homepage "http://r53-ddns.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v0.1.10
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow