### PR TITLE
Update of formula for r53-ddns tag v0.1.11

### DIFF
--- a/Formula/r53-ddns.rb
+++ b/Formula/r53-ddns.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class R53Ddns < Formula
-  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v0.1.10.tar.gz"
-  version "v0.1.10"
-  sha256 "7e94712fbb4c677fe9341a861603091d2c16bc431ea37e56f6fcdd5c442a7b5d"
+  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v0.1.11.tar.gz"
+  version "v0.1.11"
+  sha256 "be0504e0985c2b147909ddb9b54f033e14f29713d6f6d322a93683cd2cf72089"
   desc "Amazon Route 53 DDNS - `r53-ddns` - a way to keep a consistant url for a network where the external ip address may change via Amazon Route 53."
   homepage "http://r53-ddns.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v0.1.11
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow