### PR TITLE
Update of formula for r53-ddns tag v1.0.1

### DIFF
--- a/Formula/r53-ddns.rb
+++ b/Formula/r53-ddns.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class R53Ddns < Formula
-  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.0.0.tar.gz"
-  version "v1.0.0"
-  sha256 "999a3935c9ca8d610b8bc780a63176ce7aa41cd8cac918f29bfa72e21849d18b"
+  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.0.1.tar.gz"
+  version "v1.0.1"
+  sha256 "1fd225ec04364de4678b68285a69539970855826d2bf5875f980b4f01ce9e4b6"
   desc "Amazon Route 53 DDNS - `r53-ddns` - a way to keep a consistant url for a network where the external ip address may change via Amazon Route 53."
   homepage "http://r53-ddns.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.1
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow