### PR TITLE
Update of formula for r53-ddns tag v1.0.4

### DIFF
--- a/Formula/r53-ddns.rb
+++ b/Formula/r53-ddns.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class R53Ddns < Formula
-  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.0.3.tar.gz"
-  version "v1.0.3"
-  sha256 "23d7cc9c79d064fa2830119243b034f04f94895321f927c03d2dc7a0ed26330d"
+  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.0.4.tar.gz"
+  version "v1.0.4"
+  sha256 "72f753bd94c5a4fb1481cbc4a3f5421a291ff4f39ff1b280e9a4a5a646c447d3"
   desc "Amazon Route 53 DDNS - `r53-ddns` - a way to keep a consistant url for a network where the external ip address may change via Amazon Route 53."
   homepage "http://r53-ddns.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.4
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow