### PR TITLE
Update of formula for r53-ddns tag v1.0.7

### DIFF
--- a/Formula/r53-ddns.rb
+++ b/Formula/r53-ddns.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class R53Ddns < Formula
-  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.0.6.tar.gz"
-  version "v1.0.6"
-  sha256 "92c845eb333dd72e765b3dab263e7073e9f584935b24cf7303d79444cb75d82b"
+  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.0.7.tar.gz"
+  version "v1.0.7"
+  sha256 "13aef1a00d3f5d4ece0beab85dc2fdf14413cbfe48d0e2edd4e4a0fb5800c49d"
   desc "Amazon Route 53 DDNS - `r53-ddns` - a way to keep a consistant url for a network where the external ip address may change via Amazon Route 53."
   homepage "http://r53-ddns.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.7
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow