### PR TITLE
Update of formula for r53-ddns tag v1.0.11

### DIFF
--- a/Formula/r53-ddns.rb
+++ b/Formula/r53-ddns.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class R53Ddns < Formula
-  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.0.9.tar.gz"
-  version "v1.0.9"
-  sha256 "19475d401fde856a0669baf5c219544dde745bcd496142cee0a5b8da4f4dd38a"
+  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.0.11.tar.gz"
+  version "v1.0.11"
+  sha256 "e55154ea7c73d9cefbfe78992f184fdc26b018125afd3ca9ecbfaef75277395e"
   desc "Amazon Route 53 DDNS - `r53-ddns` - a way to keep a consistant url for a network where the external ip address may change via Amazon Route 53."
   homepage "http://r53-ddns.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.11
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow