### PR TITLE
Update of formula for r53-ddns tag v1.0.15

### DIFF
--- a/Formula/r53-ddns.rb
+++ b/Formula/r53-ddns.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class R53Ddns < Formula
-  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.0.14.tar.gz"
-  version "v1.0.14"
-  sha256 "295276f161f2e387310b318a29be727e62bac3ae441a3201c09a712ccb647098"
+  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.0.15.tar.gz"
+  version "v1.0.15"
+  sha256 "3c6cd56401cf9b3702e9b1166e79d7d405efff1932a2172624781774e6a7742a"
   desc "Amazon Route 53 DDNS - `r53-ddns` - a way to keep a consistant url for a network where the external ip address may change via Amazon Route 53."
   homepage "http://r53-ddns.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.15
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow