### PR TITLE
Update of formula for r53-ddns tag v1.0.16

### DIFF
--- a/Formula/r53-ddns.rb
+++ b/Formula/r53-ddns.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class R53Ddns < Formula
-  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.0.15.tar.gz"
-  version "v1.0.15"
-  sha256 "3c6cd56401cf9b3702e9b1166e79d7d405efff1932a2172624781774e6a7742a"
+  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.0.16.tar.gz"
+  version "v1.0.16"
+  sha256 "41e13cb98555fd5a1806ab0fbf06f6e42200cd141a4d2f36abda1b06703892f3"
   desc "Amazon Route 53 DDNS - `r53-ddns` - a way to keep a consistant url for a network where the external ip address may change via Amazon Route 53."
   homepage "http://r53-ddns.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.0.16
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow