### PR TITLE
Update of formula for r53-ddns tag v1.1.1

### DIFF
--- a/Formula/r53-ddns.rb
+++ b/Formula/r53-ddns.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class R53Ddns < Formula
-  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.0.16.tar.gz"
-  version "v1.0.16"
-  sha256 "41e13cb98555fd5a1806ab0fbf06f6e42200cd141a4d2f36abda1b06703892f3"
+  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.1.1.tar.gz"
+  version "v1.1.1"
+  sha256 "60c5a138dea1e5ccb76004ce5fae011415a4773ccf6f427c6b4871d5e7425b9e"
   desc "Amazon Route 53 DDNS - `r53-ddns` - a way to keep a consistant url for a network where the external ip address may change via Amazon Route 53."
   homepage "http://r53-ddns.noser.net/"
   license "Apache 2.0"
@@ -14,4 +14,3 @@ class R53Ddns < Formula
     system "cargo", "install", *std_cargo_args
   end
 end
-  


### PR DESCRIPTION
Update formula for v1.1.1
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow