### PR TITLE
Update of formula for r53-ddns tag v1.1.3

### DIFF
--- a/Formula/r53-ddns.rb
+++ b/Formula/r53-ddns.rb
@@ -1,9 +1,9 @@
 # Documentation: https://docs.brew.sh/Formula-Cookbook
 #                https://rubydoc.brew.sh/Formula
 class R53Ddns < Formula
-  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.1.2.tar.gz"
-  version "v1.1.2"
-  sha256 "52919db48729f142382d9c92a3895754a57ce893a468651a31d03898cb6083ef"
+  url "https://github.com/a1ecbr0wn/r53-ddns/archive/refs/tags/v1.1.3.tar.gz"
+  version "v1.1.3"
+  sha256 "2fb09b5882ae5f1d2c1b9e5e8c4991a321f5e0f7a261869e82baa9d0ee9225b4"
   desc "Amazon Route 53 DDNS - `r53-ddns` - a way to keep a consistant url for a network where the external ip address may change via Amazon Route 53."
   homepage "http://r53-ddns.noser.net/"
   license "Apache 2.0"


### PR DESCRIPTION
Update formula for v1.1.3
- Change to version number
- Change of source file link
- Change of SHA256 checksum to match new source file
- Auto-generated by workflow